### PR TITLE
Making changes necessary for allow for cross compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -103,7 +103,7 @@ fn prepare_tensorflow_source() -> PathBuf {
 
 fn prepare_tensorflow_library<P: AsRef<Path>>(tflite: P) {
     let tf_lib_name = PathBuf::from(env::var("OUT_DIR").unwrap()).join("libtensorflow-lite.a");
-    let os = env::var("CARGO_CFG_TARGET_OS").expect("Unabel to get TARGET_OS");
+    let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("Unable to get TARGET_ARCH");
     if !tf_lib_name.exists() {
         Command::new("make")

--- a/data/aarch64_makefile.inc
+++ b/data/aarch64_makefile.inc
@@ -1,0 +1,29 @@
+# Settings for aarch64
+$(info $$TARGET_ARCH is [${TARGET_ARCH}])
+ifeq ($(TARGET_ARCH),aarch64)
+  TARGET_TOOLCHAIN_PREFIX := aarch64-linux-gnu-
+  CXXFLAGS += \
+    -march=armv8-a \
+    -funsafe-math-optimizations \
+    -ftree-vectorize \
+    -fPIC
+
+  CCFLAGS += \
+    -march=armv8-a \
+    -funsafe-math-optimizations \
+    -ftree-vectorize \
+    -fPIC
+
+  LDFLAGS := \
+    -Wl,--no-export-dynamic \
+    -Wl,--exclude-libs,ALL \
+    -Wl,--gc-sections \
+    -Wl,--as-needed
+
+  LIBS := \
+    -lstdc++ \
+    -lpthread \
+    -lm \
+    -ldl
+
+endif


### PR DESCRIPTION
This should all most cross-compiling to work. I've tested it for aarch64 and it compiles into a binary just fine. When not cross-compiling it still works the same.

I changed some unwrap() calls to expect() to make it easier to diagnose failures as well.