### PR TITLE
Fixing clippy warnings

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy))]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::all))]
 
 pub(crate) use self::root::tflite::*;
 pub(crate) use self::root::*;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -27,7 +27,7 @@ impl<'a> Drop for Interpreter<'a> {
 
         #[cfg_attr(
             feature = "cargo-clippy",
-            allow(forget_copy, useless_transmute)
+            allow(clippy::forget_copy, clippy::useless_transmute)
         )]
         unsafe {
             cpp!([handle as "Interpreter*"] {
@@ -44,7 +44,7 @@ impl<'a> Interpreter<'a> {
     pub fn allocate_tensors(&mut self) -> Fallible<()> {
         let interpreter = self.handle;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let result = unsafe {
             cpp!([interpreter as "Interpreter*"] -> bool as "bool" {
                 return interpreter->AllocateTensors() == kTfLiteOk;
@@ -60,7 +60,7 @@ impl<'a> Interpreter<'a> {
 
         #[cfg_attr(
             feature = "cargo-clippy",
-            allow(forget_copy, useless_transmute)
+            allow(clippy::forget_copy, clippy::useless_transmute)
         )]
         unsafe {
             cpp!([interpreter as "Interpreter*"] {
@@ -73,7 +73,7 @@ impl<'a> Interpreter<'a> {
     pub fn invoke(&mut self) -> Fallible<()> {
         let interpreter = self.handle;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let result = unsafe {
             cpp!([interpreter as "Interpreter*"] -> bool as "bool" {
                 return interpreter->Invoke() == kTfLiteOk;
@@ -88,7 +88,7 @@ impl<'a> Interpreter<'a> {
         let interpreter = self.handle;
         let mut count: size_t = 0;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",
@@ -107,7 +107,7 @@ impl<'a> Interpreter<'a> {
         let interpreter = self.handle;
         let mut count: size_t = 0;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",
@@ -126,7 +126,7 @@ impl<'a> Interpreter<'a> {
         let interpreter = self.handle;
         let mut count: size_t = 0;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",
@@ -144,7 +144,7 @@ impl<'a> Interpreter<'a> {
     pub fn tensors_size(&self) -> size_t {
         let interpreter = self.handle;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         unsafe {
             cpp!([interpreter as "const Interpreter*"] -> size_t as "size_t" {
                 return interpreter->tensors_size();
@@ -156,7 +156,7 @@ impl<'a> Interpreter<'a> {
     pub fn nodes_size(&self) -> size_t {
         let interpreter = self.handle;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         unsafe {
             cpp!([interpreter as "const Interpreter*"] -> size_t as "size_t" {
                 return interpreter->nodes_size();
@@ -170,7 +170,7 @@ impl<'a> Interpreter<'a> {
         let interpreter = self.handle;
         let mut index: TensorIndex = 0;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -195,7 +195,7 @@ impl<'a> Interpreter<'a> {
         let ptr = inputs.as_ptr();
         let len = inputs.len() as size_t;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -221,7 +221,7 @@ impl<'a> Interpreter<'a> {
         let ptr = outputs.as_ptr();
         let len = outputs.len() as size_t;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -247,7 +247,7 @@ impl<'a> Interpreter<'a> {
         let ptr = variables.as_ptr();
         let len = variables.len() as size_t;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -271,7 +271,7 @@ impl<'a> Interpreter<'a> {
         element_type: ElementKind,
         name: &str,
         dims: &[usize],
-        quantization: QuantizationParams,
+        quantization: &QuantizationParams,
         is_variable: bool,
     ) -> Fallible<()> {
         let interpreter = self.handle;
@@ -283,7 +283,7 @@ impl<'a> Interpreter<'a> {
         let dims_ptr = dims.as_ptr();
         let dims_len = dims.len() as size_t;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -311,7 +311,7 @@ impl<'a> Interpreter<'a> {
     fn tensor_inner(&self, tensor_index: TensorIndex) -> Fallible<&bindings::TfLiteTensor> {
         let interpreter = self.handle;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",

--- a/src/model.rs
+++ b/src/model.rs
@@ -24,7 +24,7 @@ impl Drop for FlatBufferModel {
 
         #[cfg_attr(
             feature = "cargo-clippy",
-            allow(forget_copy, useless_transmute)
+            allow(clippy::forget_copy, clippy::useless_transmute)
         )]
         unsafe {
             cpp!([handle as "FlatBufferModel*"] {
@@ -39,7 +39,7 @@ impl FlatBufferModel {
         let path_str = CString::new(path.as_ref().to_str().unwrap())?;
         let path = path_str.as_ptr();
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let handle = unsafe {
             cpp!([path as "const char*"] -> *mut bindings::FlatBufferModel as "FlatBufferModel*" {
                 return FlatBufferModel::VerifyAndBuildFromFile(path).release();
@@ -53,7 +53,7 @@ impl FlatBufferModel {
         let ptr = buffer.as_ptr();
         let size = buffer.len();
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let handle = unsafe {
             cpp!([ptr as "const char*", size as "size_t"]
                   -> *mut bindings::FlatBufferModel as "FlatBufferModel*" {
@@ -76,7 +76,7 @@ impl<'a> Drop for InterpreterBuilder<'a> {
 
         #[cfg_attr(
             feature = "cargo-clippy",
-            allow(forget_copy, useless_transmute)
+            allow(clippy::forget_copy, clippy::useless_transmute)
         )]
         unsafe {
             cpp!([handle as "InterpreterBuilder*"] {
@@ -87,11 +87,12 @@ impl<'a> Drop for InterpreterBuilder<'a> {
 }
 
 impl<'a> InterpreterBuilder<'a> {
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::new_ret_no_self))]
     pub fn new<T: OpResolver>(model: &'a FlatBufferModel, resolver: &'a T) -> Fallible<Self> {
         let model_handle = model.handle;
         let resolver_handle = resolver.get_resolver_handle();
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let handle = unsafe {
             cpp!([model_handle as "const FlatBufferModel*",
                   resolver_handle as "const OpResolver*"
@@ -109,7 +110,7 @@ impl<'a> InterpreterBuilder<'a> {
     pub fn build(&self) -> Fallible<Interpreter> {
         let builder = self.handle;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
         let handle = unsafe {
             cpp!([builder as "InterpreterBuilder*"] -> *mut bindings::Interpreter as "Interpreter*" {
                 std::unique_ptr<Interpreter> interpreter;

--- a/src/ops/builtin/resolver.rs
+++ b/src/ops/builtin/resolver.rs
@@ -15,7 +15,7 @@ pub struct Resolver {
 impl Drop for Resolver {
     #[cfg_attr(
         feature = "cargo-clippy",
-        allow(useless_transmute, forget_copy)
+        allow(clippy::useless_transmute, clippy::forget_copy)
     )]
     fn drop(&mut self) {
         let handle = self.handle;
@@ -34,7 +34,7 @@ impl OpResolver for Resolver {
 }
 
 impl Default for Resolver {
-    #[cfg_attr(feature = "cargo-clippy", allow(forget_copy))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
     fn default() -> Self {
         let handle = unsafe {
             cpp!([] -> *mut bindings::OpResolver as "OpResolver*" {


### PR DESCRIPTION
When compiling this on rust 1.31.0 it generated a bunch of clippy warnings that I've fixed.