### PR TITLE
Make types send and sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,13 @@ keywords = ["tensorflow", "tflite", "bindings"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/boncheolgu/tflite-rs"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 cpp = "0.5"
 failure = "0.1"
 libc = "0.2"
+maybe-owned = "0.3"
 
 [build-dependencies]
 bindgen = "0.49"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ failure = "0.1"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.43"
+bindgen = "0.49"
 cpp_build = "0.5"
 curl = "0.4"
 failure = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -79,7 +79,8 @@ fn prepare_tensorflow_source() -> PathBuf {
                 "data/linux_makefile.inc",
                 tf_src_dir_inner
                     .join("tensorflow/contrib/lite/tools/make/targets/linux_makefile.inc"),
-            ).expect("Unable to copy linux makefile");
+            )
+            .expect("Unable to copy linux makefile");
         }
         // To allow for cross-compiling to aarch64
         if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "aarch64" {
@@ -87,13 +88,15 @@ fn prepare_tensorflow_source() -> PathBuf {
                 "data/aarch64_makefile.inc",
                 tf_src_dir_inner
                     .join("tensorflow/contrib/lite/tools/make/targets/aarch64_makefile.inc"),
-            ).expect("Unable to copy aarch64 makefile");
+            )
+            .expect("Unable to copy aarch64 makefile");
         }
 
         // To duplicated implementation error
         fs::remove_file(
             tf_src_dir_inner.join("tensorflow/contrib/lite/mmap_allocation_disabled.cc"),
-        ).expect("Unable to disable mmap allocation");
+        )
+        .expect("Unable to disable mmap allocation");
 
         fs::remove_file(tf_src_dir_inner.join("tensorflow/contrib/lite/nnapi_delegate.cc"))
             .expect("Unable to remove nnapi delegate");
@@ -145,7 +148,8 @@ fn prepare_tensorflow_library<P: AsRef<Path>>(tflite: P) {
                 ARCH = arch,
             )),
             &tf_lib_name,
-        ).expect("Unable to copy libtensorflow-lite.a to OUT_DIR");
+        )
+        .expect("Unable to copy libtensorflow-lite.a to OUT_DIR");
     }
 }
 
@@ -236,4 +240,3 @@ fn main() {
     import_tflite_types(&tflite_src_dir);
     build_inline_cpp(&tflite_src_dir);
 }
-

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,5 +1,4 @@
-#![allow(dead_code)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::all))]
+#![allow(dead_code, clippy::all)]
 
 pub(crate) use self::root::tflite::*;
 pub(crate) use self::root::*;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,6 @@
 use std::ffi::CStr;
 use std::fmt;
-
-use bindings;
+use crate::bindings;
 
 pub type ElementKind = bindings::TfLiteType;
 pub type QuantizationParams = bindings::TfLiteQuantizationParams;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,6 @@
+use crate::bindings;
 use std::ffi::CStr;
 use std::fmt;
-use crate::bindings;
 
 pub type ElementKind = bindings::TfLiteType;
 pub type QuantizationParams = bindings::TfLiteQuantizationParams;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -4,10 +4,10 @@ use std::slice;
 use failure::Fallible;
 use libc::{c_int, size_t};
 
-use crate::InterpreterBuilder;
+use crate::bindings;
 use crate::context::{ElemKindOf, ElementKind, QuantizationParams, TensorInfo};
 use crate::op_resolver::OpResolver;
-use crate::bindings;
+use crate::InterpreterBuilder;
 
 cpp! {{
     #include "tensorflow/contrib/lite/interpreter.h"
@@ -19,13 +19,17 @@ cpp! {{
 pub type TensorIndex = c_int;
 
 pub struct Interpreter<'a, Op>
-where Op: OpResolver + 'a {
+where
+    Op: OpResolver,
+{
     handle: Box<bindings::Interpreter>,
     _builder: InterpreterBuilder<'a, Op>,
 }
 
 impl<'a, Op> Drop for Interpreter<'a, Op>
-where Op: OpResolver + 'a {
+where
+    Op: OpResolver,
+{
     fn drop(&mut self) {
         let handle = std::mem::replace(&mut self.handle, Default::default());
         let handle = Box::into_raw(handle);
@@ -39,7 +43,9 @@ where Op: OpResolver + 'a {
 }
 
 impl<'a, Op> Interpreter<'a, Op>
-where Op: OpResolver + 'a {
+where
+    Op: OpResolver,
+{
     fn handle(&self) -> &bindings::Interpreter {
         use std::ops::Deref;
         self.handle.deref()
@@ -48,10 +54,13 @@ where Op: OpResolver + 'a {
         use std::ops::DerefMut;
         self.handle.deref_mut()
     }
-    pub(crate) fn new(handle: Box<bindings::Interpreter>, builder: InterpreterBuilder<'a, Op>) -> Self {
+    pub(crate) fn new(
+        handle: Box<bindings::Interpreter>,
+        builder: InterpreterBuilder<'a, Op>,
+    ) -> Self {
         Self {
             handle,
-            _builder: builder
+            _builder: builder,
         }
     }
     /// Update allocations for all tensors. This will redim dependent tensors using

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -4,7 +4,7 @@ use std::slice;
 use failure::Fallible;
 use libc::{c_int, size_t};
 
-use bindings;
+use ::{bindings, InterpreterBuilder};
 use context::{ElemKindOf, ElementKind, QuantizationParams, TensorInfo};
 
 cpp! {{
@@ -17,18 +17,15 @@ cpp! {{
 pub type TensorIndex = c_int;
 
 pub struct Interpreter<'a> {
-    pub(crate) handle: *mut bindings::Interpreter,
-    pub(crate) phantom: ::std::marker::PhantomData<&'a ()>,
+    handle: Box<bindings::Interpreter>,
+    _builder: InterpreterBuilder<'a>,
 }
 
 impl<'a> Drop for Interpreter<'a> {
     fn drop(&mut self) {
-        let handle = self.handle;
-
-        #[cfg_attr(
-            feature = "cargo-clippy",
-            allow(clippy::forget_copy, clippy::useless_transmute)
-        )]
+        let handle = std::mem::replace(&mut self.handle, Default::default());
+        let handle = Box::into_raw(handle);
+        #[allow(clippy::forget_copy, clippy::useless_transmute)]
         unsafe {
             cpp!([handle as "Interpreter*"] {
                 delete handle;
@@ -38,13 +35,27 @@ impl<'a> Drop for Interpreter<'a> {
 }
 
 impl<'a> Interpreter<'a> {
+    fn handle(&self) -> &bindings::Interpreter {
+        use std::ops::Deref;
+        self.handle.deref()
+    }
+    fn handle_mut(&mut self) -> &mut bindings::Interpreter {
+        use std::ops::DerefMut;
+        self.handle.deref_mut()
+    }
+    pub(crate) fn new(handle: Box<bindings::Interpreter>, builder: InterpreterBuilder<'a>) -> Self {
+        Self {
+            handle,
+            _builder: builder
+        }
+    }
     /// Update allocations for all tensors. This will redim dependent tensors using
     /// the input tensor dimensionality as given. This is relatively expensive.
     /// If you know that your sizes are not changing, you need not call this.
     pub fn allocate_tensors(&mut self) -> Fallible<()> {
-        let interpreter = self.handle;
+        let interpreter = self.handle_mut();
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let result = unsafe {
             cpp!([interpreter as "Interpreter*"] -> bool as "bool" {
                 return interpreter->AllocateTensors() == kTfLiteOk;
@@ -56,12 +67,9 @@ impl<'a> Interpreter<'a> {
 
     /// Prints a dump of what tensors and what nodes are in the interpreter.
     pub fn print_state(&self) {
-        let interpreter = self.handle;
+        let interpreter = self.handle();
 
-        #[cfg_attr(
-            feature = "cargo-clippy",
-            allow(clippy::forget_copy, clippy::useless_transmute)
-        )]
+        #[allow(clippy::forget_copy, clippy::useless_transmute)]
         unsafe {
             cpp!([interpreter as "Interpreter*"] {
                 PrintInterpreterState(interpreter);
@@ -71,9 +79,9 @@ impl<'a> Interpreter<'a> {
 
     /// Invoke the interpreter (run the whole graph in dependency order).
     pub fn invoke(&mut self) -> Fallible<()> {
-        let interpreter = self.handle;
+        let interpreter = self.handle_mut();
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let result = unsafe {
             cpp!([interpreter as "Interpreter*"] -> bool as "bool" {
                 return interpreter->Invoke() == kTfLiteOk;
@@ -85,10 +93,10 @@ impl<'a> Interpreter<'a> {
 
     /// Read only access to list of inputs.
     pub fn inputs(&self) -> &[TensorIndex] {
-        let interpreter = self.handle;
+        let interpreter = self.handle();
         let mut count: size_t = 0;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",
@@ -104,10 +112,10 @@ impl<'a> Interpreter<'a> {
 
     /// Read only access to list of outputs.
     pub fn outputs(&self) -> &[TensorIndex] {
-        let interpreter = self.handle;
+        let interpreter = self.handle();
         let mut count: size_t = 0;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",
@@ -123,10 +131,10 @@ impl<'a> Interpreter<'a> {
 
     /// Read only access to list of variable tensors.
     pub fn variables(&self) -> &[TensorIndex] {
-        let interpreter = self.handle;
+        let interpreter = self.handle();
         let mut count: size_t = 0;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",
@@ -142,9 +150,9 @@ impl<'a> Interpreter<'a> {
 
     /// Return the number of tensors in the model.
     pub fn tensors_size(&self) -> size_t {
-        let interpreter = self.handle;
+        let interpreter = self.handle();
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         unsafe {
             cpp!([interpreter as "const Interpreter*"] -> size_t as "size_t" {
                 return interpreter->tensors_size();
@@ -154,9 +162,9 @@ impl<'a> Interpreter<'a> {
 
     /// Return the number of ops in the model.
     pub fn nodes_size(&self) -> size_t {
-        let interpreter = self.handle;
+        let interpreter = self.handle();
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         unsafe {
             cpp!([interpreter as "const Interpreter*"] -> size_t as "size_t" {
                 return interpreter->nodes_size();
@@ -167,10 +175,10 @@ impl<'a> Interpreter<'a> {
     /// Adds `count` tensors, preserving pre-existing Tensor entries.
     /// Return the index of the first new tensor.
     pub fn add_tensors(&mut self, count: size_t) -> Fallible<TensorIndex> {
-        let interpreter = self.handle;
+        let interpreter = self.handle();
         let mut index: TensorIndex = 0;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -191,11 +199,11 @@ impl<'a> Interpreter<'a> {
     /// Each index is bound check and this modifies the consistent_ flag of the
     /// interpreter.
     pub fn set_inputs(&mut self, inputs: &[TensorIndex]) -> Fallible<()> {
-        let interpreter = self.handle;
+        let interpreter = self.handle_mut();
         let ptr = inputs.as_ptr();
         let len = inputs.len() as size_t;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -217,11 +225,11 @@ impl<'a> Interpreter<'a> {
     /// Each index is bound check and this modifies the consistent_ flag of the
     /// interpreter.
     pub fn set_outputs(&mut self, outputs: &[TensorIndex]) -> Fallible<()> {
-        let interpreter = self.handle;
+        let interpreter = self.handle_mut();
         let ptr = outputs.as_ptr();
         let len = outputs.len() as size_t;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -243,11 +251,11 @@ impl<'a> Interpreter<'a> {
     /// Each index is bound check and this modifies the consistent_ flag of the
     /// interpreter.
     pub fn set_variables(&mut self, variables: &[TensorIndex]) -> Fallible<()> {
-        let interpreter = self.handle;
+        let interpreter = self.handle_mut();
         let ptr = variables.as_ptr();
         let len = variables.len() as size_t;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -266,7 +274,7 @@ impl<'a> Interpreter<'a> {
     }
 
     pub fn set_tensor_parameters_read_write(
-        &self,
+        &mut self,
         tensor_index: TensorIndex,
         element_type: ElementKind,
         name: &str,
@@ -274,7 +282,7 @@ impl<'a> Interpreter<'a> {
         quantization: &QuantizationParams,
         is_variable: bool,
     ) -> Fallible<()> {
-        let interpreter = self.handle;
+        let interpreter = self.handle_mut();
 
         let name_ptr = name.as_ptr();
         let name_len = name.len() as size_t;
@@ -283,7 +291,7 @@ impl<'a> Interpreter<'a> {
         let dims_ptr = dims.as_ptr();
         let dims_len = dims.len() as size_t;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -309,9 +317,9 @@ impl<'a> Interpreter<'a> {
     }
 
     fn tensor_inner(&self, tensor_index: TensorIndex) -> Fallible<&bindings::TfLiteTensor> {
-        let interpreter = self.handle;
+        let interpreter = self.handle();
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::forget_copy))]
+        #[allow(clippy::forget_copy)]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 extern crate cpp;
 #[macro_use]
 extern crate failure;
-extern crate libc;
 
 mod bindings;
 pub mod context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,17 +13,3 @@ pub mod ops;
 
 pub use interpreter::Interpreter;
 pub use model::{FlatBufferModel, InterpreterBuilder};
-
-#[test]
-#[should_panic]
-fn threadsafe_types() {
-    fn send_sync<T: Send + Sync>(_t: &T) {}
-    let model = FlatBufferModel::default();
-    send_sync(&model);
-    let resolver = ops::builtin::resolver::Resolver::default();
-    send_sync(&resolver);
-    let builder = InterpreterBuilder::<'static>::new(&model, &resolver).expect("Not able to build builder");
-    send_sync(&builder);
-    let interpreter = builder.build().expect("Not able to build model");
-    send_sync(&interpreter);
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,17 @@ pub mod ops;
 
 pub use interpreter::Interpreter;
 pub use model::{FlatBufferModel, InterpreterBuilder};
+
+#[test]
+#[should_panic]
+fn threadsafe_types() {
+    fn send_sync<T: Send + Sync>(_t: &T) {}
+    let model = FlatBufferModel::default();
+    send_sync(&model);
+    let resolver = ops::builtin::resolver::Resolver::default();
+    send_sync(&resolver);
+    let builder = InterpreterBuilder::<'static>::new(&model, &resolver).expect("Not able to build builder");
+    send_sync(&builder);
+    let interpreter = builder.build().expect("Not able to build model");
+    send_sync(&interpreter);
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 
 use failure::Fallible;
 
+use crate::bindings;
 use crate::interpreter::Interpreter;
 use crate::op_resolver::OpResolver;
-use crate::bindings;
 use maybe_owned::MaybeOwned;
 
 cpp! {{
@@ -46,7 +46,7 @@ impl FlatBufferModel {
             })
         };
         ensure!(!handle.is_null(), "Building FlatBufferModel failed.");
-        let handle = unsafe{Box::from_raw(handle)};
+        let handle = unsafe { Box::from_raw(handle) };
         Ok(FlatBufferModel { handle })
     }
 
@@ -62,20 +62,24 @@ impl FlatBufferModel {
             })
         };
         ensure!(!handle.is_null(), "Building FlatBufferModel failed.");
-        let handle = unsafe{Box::from_raw(handle)};
+        let handle = unsafe { Box::from_raw(handle) };
         Ok(FlatBufferModel { handle })
     }
 }
 
 pub struct InterpreterBuilder<'a, Op>
-where Op: OpResolver + 'a {
+where
+    Op: OpResolver,
+{
     handle: Box<bindings::InterpreterBuilder>,
     _model: MaybeOwned<'a, FlatBufferModel>,
     _resolver: Op,
 }
 
 impl<'a, Op> Drop for InterpreterBuilder<'a, Op>
-where Op: OpResolver + 'a {
+where
+    Op: OpResolver,
+{
     fn drop(&mut self) {
         let handle = std::mem::replace(&mut self.handle, Default::default());
         let handle = Box::into_raw(handle);
@@ -89,7 +93,9 @@ where Op: OpResolver + 'a {
 }
 
 impl<'a, Op> InterpreterBuilder<'a, Op>
-where Op: OpResolver + 'a {
+where
+    Op: OpResolver,
+{
     #[allow(clippy::new_ret_no_self)]
     pub fn new<M: Into<MaybeOwned<'a, FlatBufferModel>>>(model: M, resolver: Op) -> Fallible<Self> {
         use std::ops::Deref;
@@ -108,7 +114,7 @@ where Op: OpResolver + 'a {
             }
         };
         ensure!(!handle.is_null(), "Creating InterpreterBuilder failed.");
-        let handle = unsafe {Box::from_raw(handle)};
+        let handle = unsafe { Box::from_raw(handle) };
         Ok(Self {
             handle,
             _model: model,
@@ -117,7 +123,6 @@ where Op: OpResolver + 'a {
     }
 
     pub fn build(mut self) -> Fallible<Interpreter<'a, Op>> {
-
         #[allow(clippy::forget_copy)]
         let handle = {
             let builder = &mut *self.handle;
@@ -130,7 +135,7 @@ where Op: OpResolver + 'a {
             }
         };
         ensure!(!handle.is_null(), "Building Interpreter failed.");
-        let handle = unsafe {Box::from_raw(handle)};
+        let handle = unsafe { Box::from_raw(handle) };
         Ok(Interpreter::new(handle, self))
     }
 }

--- a/src/op_resolver.rs
+++ b/src/op_resolver.rs
@@ -1,5 +1,17 @@
-use bindings;
+use std::sync::Arc;
 
 pub trait OpResolver: Send + Sync {
-    fn get_resolver_handle(&self) -> &bindings::OpResolver;
+    fn get_resolver_handle(&self) -> &crate::bindings::OpResolver;
+}
+
+impl<T: OpResolver> OpResolver for Arc<T> {
+    fn get_resolver_handle(&self) -> &crate::bindings::OpResolver {
+        self.as_ref().get_resolver_handle()
+    }
+}
+
+impl<'a, T: OpResolver> OpResolver for &'a T {
+    fn get_resolver_handle(&self) -> &crate::bindings::OpResolver {
+        (*self).get_resolver_handle()
+    }
 }

--- a/src/op_resolver.rs
+++ b/src/op_resolver.rs
@@ -1,5 +1,5 @@
 use bindings;
 
-pub trait OpResolver {
-    fn get_resolver_handle(&self) -> *mut bindings::OpResolver;
+pub trait OpResolver: Send + Sync {
+    fn get_resolver_handle(&self) -> &bindings::OpResolver;
 }

--- a/src/op_resolver.rs
+++ b/src/op_resolver.rs
@@ -1,17 +1,18 @@
+use crate::bindings::OpResolver as SysOpResolver;
 use std::sync::Arc;
 
 pub trait OpResolver: Send + Sync {
-    fn get_resolver_handle(&self) -> &crate::bindings::OpResolver;
+    fn get_resolver_handle(&self) -> &SysOpResolver;
 }
 
 impl<T: OpResolver> OpResolver for Arc<T> {
-    fn get_resolver_handle(&self) -> &crate::bindings::OpResolver {
+    fn get_resolver_handle(&self) -> &SysOpResolver {
         self.as_ref().get_resolver_handle()
     }
 }
 
 impl<'a, T: OpResolver> OpResolver for &'a T {
-    fn get_resolver_handle(&self) -> &crate::bindings::OpResolver {
+    fn get_resolver_handle(&self) -> &SysOpResolver {
         (*self).get_resolver_handle()
     }
 }

--- a/src/ops/builtin/resolver.rs
+++ b/src/ops/builtin/resolver.rs
@@ -1,6 +1,5 @@
-use op_resolver::OpResolver;
-
-use bindings;
+use crate::op_resolver::OpResolver;
+use crate::bindings;
 
 cpp! {{
     #include "tensorflow/contrib/lite/kernels/register.h"

--- a/src/ops/builtin/resolver.rs
+++ b/src/ops/builtin/resolver.rs
@@ -1,5 +1,5 @@
-use crate::op_resolver::OpResolver;
 use crate::bindings;
+use crate::op_resolver::OpResolver;
 
 cpp! {{
     #include "tensorflow/contrib/lite/kernels/register.h"
@@ -26,8 +26,7 @@ impl Drop for Resolver {
 
 impl OpResolver for Resolver {
     fn get_resolver_handle(&self) -> &bindings::OpResolver {
-        use std::ops::Deref;
-        self.handle.deref()
+        self.handle.as_ref()
     }
 }
 
@@ -39,7 +38,7 @@ impl Default for Resolver {
                 return new BuiltinOpResolver();
             })
         };
-        let handle = unsafe{Box::from_raw(handle)};
+        let handle = unsafe { Box::from_raw(handle) };
         Self { handle }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,6 +9,7 @@ use failure::Fallible;
 
 use tflite::ops::builtin::BuiltinOpResolver;
 use tflite::{FlatBufferModel, InterpreterBuilder};
+use std::sync::Arc;
 
 fn test_mnist(model: &FlatBufferModel) -> Fallible<()> {
     let resolver = BuiltinOpResolver::default();
@@ -81,9 +82,9 @@ fn threadsafe_types() {
     fn send_sync<T: Send + Sync>(_t: &T) {}
     let model = FlatBufferModel::build_from_file("data/MNISTnet_uint8_quant.tflite").expect("Unable to build flatbuffer model");
     send_sync(&model);
-    let resolver = BuiltinOpResolver::default();
+    let resolver = Arc::new(BuiltinOpResolver::default());
     send_sync(&resolver);
-    let builder = InterpreterBuilder::new(&model, &resolver).expect("Not able to build builder");
+    let builder = InterpreterBuilder::new(model, resolver).expect("Not able to build builder");
     send_sync(&builder);
     let interpreter = builder.build().expect("Not able to build model");
     send_sync(&interpreter);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -75,3 +75,16 @@ fn mobilenetv2_mnist() {
     f.read_to_end(&mut buf).unwrap();
     test_mnist(&FlatBufferModel::build_from_buffer(&buf).unwrap()).unwrap();
 }
+
+#[test]
+fn threadsafe_types() {
+    fn send_sync<T: Send + Sync>(_t: &T) {}
+    let model = FlatBufferModel::build_from_file("data/MNISTnet_uint8_quant.tflite").expect("Unable to build flatbuffer model");
+    send_sync(&model);
+    let resolver = BuiltinOpResolver::default();
+    send_sync(&resolver);
+    let builder = InterpreterBuilder::new(&model, &resolver).expect("Not able to build builder");
+    send_sync(&builder);
+    let interpreter = builder.build().expect("Not able to build model");
+    send_sync(&interpreter);
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,9 +7,9 @@ use std::io::Read;
 
 use failure::Fallible;
 
+use std::sync::Arc;
 use tflite::ops::builtin::BuiltinOpResolver;
 use tflite::{FlatBufferModel, InterpreterBuilder};
-use std::sync::Arc;
 
 fn test_mnist(model: &FlatBufferModel) -> Fallible<()> {
     let resolver = BuiltinOpResolver::default();
@@ -80,7 +80,8 @@ fn mobilenetv2_mnist() {
 #[test]
 fn threadsafe_types() {
     fn send_sync<T: Send + Sync>(_t: &T) {}
-    let model = FlatBufferModel::build_from_file("data/MNISTnet_uint8_quant.tflite").expect("Unable to build flatbuffer model");
+    let model = FlatBufferModel::build_from_file("data/MNISTnet_uint8_quant.tflite")
+        .expect("Unable to build flatbuffer model");
     send_sync(&model);
     let resolver = Arc::new(BuiltinOpResolver::default());
     send_sync(&resolver);


### PR DESCRIPTION
I'm using this in an Actix framework and none of the types are Send or Sync since they hold `*mut` pointers. I changed all of them to boxes which are Send and Sync. I did change the internal definition to hold references to the other types rather than a phantom reference to a borrow. Creating defaults in rust to replace the existing box in the drop impls should be fine since it will never be called again.

All tests pass on linux. On my mac the tests have a bus error on the current master and this branch, so it's not a regression. All the tests worked without changes, so I don't think this is a breaking change.

I also cleaned up the allows for clippy since it can be used without a nightly feature. 