### PR TITLE
Exclude everything that isn't necessary to get crate size down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
   - cargo build --verbose --features debug_tflite
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cargo test --features debug_tflite -- --nocapture ; fi
   # Make sure package size is under 10 MB
-  - cargo package --verbose && [ $(stat -c %s target/package/tflite-*.crate) -le 10485760 ]
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cargo package --verbose && [ $(stat -c %s target/package/tflite-*.crate) -le 10485760 ] ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cargo test -- --nocapture ; fi
   - cargo build --verbose --features debug_tflite
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cargo test --features debug_tflite -- --nocapture ; fi
+  # Make sure package size is under 10 MB
+  - cargo package --verbose && [ $(stat -c %s target/package/tflite-*.crate) -le 10485760 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,33 @@ readme = "README.md"
 edition = "2018"
 documentation = "https://docs.rs/crate/tflite"
 
+exclude = [
+  "submodules/tensorflow/tensorflow/*.bzl",
+  "submodules/tensorflow/tensorflow/*.lds",
+  "submodules/tensorflow/tensorflow/*.py",
+  "submodules/tensorflow/tensorflow/c",
+  "submodules/tensorflow/tensorflow/cc",
+  "submodules/tensorflow/tensorflow/compiler",
+  "submodules/tensorflow/tensorflow/contrib",
+  "submodules/tensorflow/tensorflow/core",
+  "submodules/tensorflow/tensorflow/docs_src",
+  "submodules/tensorflow/tensorflow/examples",
+  "submodules/tensorflow/tensorflow/g3doc",
+  "submodules/tensorflow/tensorflow/go",
+  "submodules/tensorflow/tensorflow/java",
+  "submodules/tensorflow/tensorflow/js",
+  "submodules/tensorflow/tensorflow/lite/g3doc",
+  "submodules/tensorflow/tensorflow/lite/java",
+  "submodules/tensorflow/tensorflow/lite/python",
+  "submodules/tensorflow/tensorflow/lite/testing",
+  "submodules/tensorflow/tensorflow/lite/toco",
+  "submodules/tensorflow/tensorflow/python",
+  "submodules/tensorflow/tensorflow/stream_executor",
+  "submodules/tensorflow/tensorflow/tools",
+  "submodules/tensorflow/third_party/icu",
+  "submodules/tensorflow/third_party/toolchains",
+]
+
 [dependencies]
 cpp = "0.5"
 failure = "0.1"


### PR DESCRIPTION
Hopefully fixes #21. 
I'm having an error building this locally from the cpp crate. It doesn't happen when I cross compile for aarch64 or when I build on my mac. Wondering if this will pass ci. 