### PR TITLE
Fix link directive using link_dir instead of library name

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -158,7 +158,7 @@ fn prepare_tensorflow_library() {
         } else {
             "dylib"
         };
-        println!("cargo:rustc-link-lib={}={}", static_dynamic, lib_dir);
+        println!("cargo:rustc-link-lib={}=tensorflow-lite", static_dynamic);
         println!("cargo:rerun-if-changed={}", lib_dir);
     }
     println!("cargo:rustc-link-lib=dylib=pthread");


### PR DESCRIPTION
Currently, builds with `feature = build` unset always fail since the cargo link directive is using the link directory instead of the library name.