### PR TITLE
Allow configuring more environment variables for the tensorflow build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -130,11 +130,11 @@ fn prepare_tensorflow_library() {
                 .arg("-f")
                 .arg("tensorflow/lite/tools/make/Makefile");
 
-            for &make_var in &[
-                "TARGET",
-                "TARGET_ARCH",
-                "TARGET_TOOLCHAIN_PREFIX",
-                "EXTRA_CFLAGS",
+            for (make_var, default) in &[
+                ("TARGET", Some(target.as_str())),
+                ("TARGET_ARCH", Some(arch.as_str())),
+                ("TARGET_TOOLCHAIN_PREFIX", None),
+                ("EXTRA_CFLAGS", None),
             ] {
                 let env_var = format!("TFLITE_RS_MAKE_{}", make_var);
                 println!("cargo:rerun-if-env-changed={}", env_var);
@@ -145,14 +145,8 @@ fn prepare_tensorflow_library() {
                     }
                     Err(VarError::NotPresent) => {
                         // Try and set some reasonable default values
-                        match make_var {
-                            "TARGET" => {
-                                make.arg(format!("TARGET={}", target));
-                            }
-                            "TARGET_ARCH" => {
-                                make.arg(format!("TARGET_ARCH={}", arch));
-                            }
-                            _ => {}
+                        if let Some(result) = default {
+                            make.arg(format!("{}={}", make_var, result));
                         }
                     }
                     Err(VarError::NotUnicode(_)) => {

--- a/build.rs
+++ b/build.rs
@@ -131,8 +131,10 @@ fn prepare_tensorflow_library() {
                 .arg("tensorflow/lite/tools/make/Makefile");
 
             for &make_var in &[
+                "TARGET",
+                "TARGET_ARCH",
                 "TARGET_TOOLCHAIN_PREFIX",
-                "EXTRA_CFLAGS"
+                "EXTRA_CFLAGS",
             ] {
                 let env_var = format!("TFLITE_RS_MAKE_{}", make_var);
                 println!("cargo:rerun-if-env-changed={}", env_var);

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 #[cfg(feature = "build")]
 use std::time::Instant;
+use std::env::VarError;
 
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
@@ -118,9 +119,7 @@ fn prepare_tensorflow_library() {
 
             let make_dir = tflite.parent().unwrap();
 
-            make.arg(format!("TARGET={}", target))
-                .arg(format!("TARGET_ARCH={}", arch))
-                .arg("-j")
+            make.arg("-j")
                 // allow parallelism to be overridden
                 .arg(
                     env::var("TFLITE_RS_MAKE_PARALLELISM").unwrap_or_else(|_| {
@@ -130,6 +129,35 @@ fn prepare_tensorflow_library() {
                 .arg("BUILD_WITH_NNAPI=false")
                 .arg("-f")
                 .arg("tensorflow/lite/tools/make/Makefile");
+
+            for &make_var in &[
+                "TARGET_TOOLCHAIN_PREFIX",
+                "EXTRA_CFLAGS"
+            ] {
+                let env_var = format!("TFLITE_RS_MAKE_{}", make_var);
+                println!("cargo:rerun-if-env-changed={}", env_var);
+
+                match env::var(&env_var) {
+                    Ok(result) => {
+                        make.arg(format!("{}={}", make_var, result));
+                    }
+                    Err(VarError::NotPresent) => {
+                        // Try and set some reasonable default values
+                        match make_var {
+                            "TARGET" => {
+                                make.arg(format!("TARGET={}", target));
+                            }
+                            "TARGET_ARCH" => {
+                                make.arg(format!("TARGET_ARCH={}", arch));
+                            }
+                            _ => {}
+                        }
+                    }
+                    Err(VarError::NotUnicode(_)) => {
+                        panic!("Provided a non-unicode value for {}", env_var)
+                    }
+                }
+            }
 
             if cfg!(feature = "no_micro") {
                 println!("Building lib but no micro");


### PR DESCRIPTION
I'm building tensorflow for an ARM chip, and needed to pass some specific variables through to the underlying build. There didn't seem to be a good way to infer them from the information already available in the build script, so this lets the builder pass them in ~directly.

I'd be happy to add some documentation to the readme if you approve of the overall idea!