### PR TITLE
Mark `_Tp` as non-`Copy`able to workaround bindgen bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ thiserror = "1.0.38"
 [build-dependencies]
 bart = { version = "0.1.6", optional = true }
 bart_derive = { version = "0.1.6", optional = true }
-bindgen = "0.65.1"
+bindgen = "0.69.4"
 cpp_build = "0.5.7"
 fs_extra = { version = "1.3.0", optional = true }
 

--- a/build.rs
+++ b/build.rs
@@ -253,7 +253,8 @@ fn import_tflite_types() {
         .clang_arg("c++")
         .clang_arg("-std=c++11")
         // required to get cross compilation for aarch64 to work because of an issue in flatbuffers
-        .clang_arg("-fms-extensions");
+        .clang_arg("-fms-extensions")
+        .no_copy("_Tp");
 
     let bindings = bindings.generate().expect("Unable to generate bindings");
 

--- a/data/memory_basic_impl.rs.template
+++ b/data/memory_basic_impl.rs.template
@@ -20,7 +20,7 @@ impl Deref for UniquePtr<{{{rust_type}}}> {
         unsafe {
             let ptr = cpp!([self as "const std::unique_ptr<{{{cpp_type}}}>*"] -> *const {{{rust_type}}} as "const {{{cpp_type}}}*" {
                 return self->get();
-            }) as *const Self::Target;
+            });
 
             ptr.as_ref().unwrap()
         }
@@ -33,7 +33,7 @@ impl DerefMut for UniquePtr<{{{rust_type}}}> {
         unsafe {
             let ptr = cpp!([self as "std::unique_ptr<{{{cpp_type}}}>*"] -> *mut {{{rust_type}}} as "{{{cpp_type}}}*" {
                 return self->get();
-            }) as *mut Self::Target;
+            });
 
             ptr.as_mut().unwrap()
         }

--- a/src/interpreter/builder.rs
+++ b/src/interpreter/builder.rs
@@ -28,7 +28,7 @@ where
 {
     fn drop(&mut self) {
         let handle = Box::into_raw(std::mem::take(&mut self.handle));
-        #[allow(clippy::forget_copy, clippy::useless_transmute, deprecated)]
+        #[allow(clippy::forgetting_copy_types, clippy::useless_transmute, deprecated)]
         unsafe {
             cpp!([handle as "InterpreterBuilder*"] {
                 delete handle;
@@ -49,7 +49,7 @@ where
             let model_handle = model.as_ref().handle.deref() as *const _;
             let resolver_handle = resolver.get_resolver_handle() as *const _;
 
-            #[allow(clippy::forget_copy, deprecated)]
+            #[allow(clippy::forgetting_copy_types, deprecated)]
             unsafe {
                 cpp!([model_handle as "const FlatBufferModel*",
                     resolver_handle as "const OpResolver*"
@@ -66,7 +66,7 @@ where
     }
 
     pub fn build(mut self) -> Result<Interpreter<'a, Op>> {
-        #[allow(clippy::forget_copy, deprecated)]
+        #[allow(clippy::forgetting_copy_types, deprecated)]
         let handle = {
             let builder = (&mut *self.handle) as *mut _;
             unsafe {
@@ -87,7 +87,7 @@ where
         mut self,
         threads: std::os::raw::c_int,
     ) -> Result<Interpreter<'a, Op>> {
-        #[allow(clippy::forget_copy, deprecated)]
+        #[allow(clippy::forgetting_copy_types, deprecated)]
         let handle = {
             let builder = (&mut *self.handle) as *mut _;
             #[allow(clippy::transmute_num_to_bytes)]

--- a/src/interpreter/fbmodel.rs
+++ b/src/interpreter/fbmodel.rs
@@ -22,7 +22,7 @@ impl Drop for FlatBufferModel {
     fn drop(&mut self) {
         let handle = Box::into_raw(mem::take(&mut self.handle));
 
-        #[allow(clippy::forget_copy, clippy::useless_transmute, deprecated)]
+        #[allow(clippy::forgetting_copy_types, clippy::useless_transmute, deprecated)]
         unsafe {
             cpp!([handle as "FlatBufferModel*"] {
                 delete handle;
@@ -40,7 +40,7 @@ impl FlatBufferModel {
         let ptr = model_buffer.as_ptr();
         let size = model_buffer.len();
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let handle = unsafe {
             cpp!([ptr as "const char*", size as "size_t"]
                   -> *mut bindings::FlatBufferModel as "FlatBufferModel*" {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -38,7 +38,7 @@ where
 {
     fn drop(&mut self) {
         let handle = Box::into_raw(mem::take(&mut self.handle));
-        #[allow(clippy::forget_copy, clippy::useless_transmute, deprecated)]
+        #[allow(clippy::forgetting_copy_types, clippy::useless_transmute, deprecated)]
         unsafe {
             cpp!([handle as "Interpreter*"] {
                 delete handle;
@@ -82,7 +82,7 @@ where
     pub fn allocate_tensors(&mut self) -> Result<()> {
         let interpreter = self.handle_mut() as *mut _;
 
-        #[allow(clippy::forget_copy, deprecated)]
+        #[allow(clippy::forgetting_copy_types, deprecated)]
         let r = unsafe {
             cpp!([interpreter as "Interpreter*"] -> bool as "bool" {
                 return interpreter->AllocateTensors() == kTfLiteOk;
@@ -119,7 +119,7 @@ where
     pub fn print_state(&self) {
         let interpreter = self.handle() as *const _;
 
-        #[allow(clippy::forget_copy, clippy::useless_transmute, deprecated)]
+        #[allow(clippy::forgetting_copy_types, clippy::useless_transmute, deprecated)]
         unsafe {
             cpp!([interpreter as "Interpreter*"] {
                 PrintInterpreterState(interpreter);
@@ -153,7 +153,7 @@ where
     pub fn set_num_threads(&mut self, threads: c_int) {
         let interpreter = self.handle_mut() as *mut _;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         unsafe {
             cpp!([interpreter as "Interpreter*", threads as "int"] {
                 interpreter->SetNumThreads(threads);
@@ -167,7 +167,7 @@ where
         let interpreter = self.handle() as *const _;
         let mut count: size_t = 0;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",
@@ -186,7 +186,7 @@ where
         let interpreter = self.handle() as *const _;
         let mut count: size_t = 0;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",
@@ -205,7 +205,7 @@ where
         let interpreter = self.handle() as *const _;
         let mut count: size_t = 0;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",
@@ -223,7 +223,7 @@ where
     pub fn tensors_size(&self) -> size_t {
         let interpreter = self.handle() as *const _;
 
-        #[allow(clippy::forget_copy, deprecated)]
+        #[allow(clippy::forgetting_copy_types, deprecated)]
         unsafe {
             cpp!([interpreter as "const Interpreter*"] -> size_t as "size_t" {
                 return interpreter->tensors_size();
@@ -235,7 +235,7 @@ where
     pub fn nodes_size(&self) -> size_t {
         let interpreter = self.handle() as *const _;
 
-        #[allow(clippy::forget_copy, deprecated)]
+        #[allow(clippy::forgetting_copy_types, deprecated)]
         unsafe {
             cpp!([interpreter as "const Interpreter*"] -> size_t as "size_t" {
                 return interpreter->nodes_size();
@@ -249,7 +249,7 @@ where
         let interpreter = self.handle_mut() as *mut _;
         let mut index: TensorIndex = 0;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -274,7 +274,7 @@ where
         let ptr = inputs.as_ptr();
         let len = inputs.len() as size_t;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -300,7 +300,7 @@ where
         let ptr = outputs.as_ptr();
         let len = outputs.len() as size_t;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -326,7 +326,7 @@ where
         let ptr = variables.as_ptr();
         let len = variables.len() as size_t;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -363,7 +363,7 @@ where
         let dims_ptr = dims.as_ptr();
         let dims_len = dims.len() as size_t;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let result = unsafe {
             cpp!([
                 interpreter as "Interpreter*",
@@ -391,7 +391,7 @@ where
     fn tensor_inner(&self, tensor_index: TensorIndex) -> Option<&bindings::TfLiteTensor> {
         let interpreter = self.handle() as *const _;
 
-        #[allow(clippy::forget_copy, deprecated, clippy::transmute_num_to_bytes)]
+        #[allow(clippy::forgetting_copy_types, deprecated, clippy::transmute_num_to_bytes)]
         let ptr = unsafe {
             cpp!([
                 interpreter as "const Interpreter*",

--- a/src/interpreter/ops/builtin/resolver.rs
+++ b/src/interpreter/ops/builtin/resolver.rs
@@ -14,7 +14,7 @@ pub struct Resolver {
 }
 
 impl Drop for Resolver {
-    #[allow(clippy::useless_transmute, clippy::forget_copy, deprecated)]
+    #[allow(clippy::useless_transmute, clippy::forgetting_copy_types, deprecated)]
     fn drop(&mut self) {
         let handle = Box::into_raw(mem::take(&mut self.handle));
         unsafe {
@@ -32,7 +32,7 @@ impl OpResolver for Resolver {
 }
 
 impl Default for Resolver {
-    #[allow(clippy::forget_copy, deprecated)]
+    #[allow(clippy::forgetting_copy_types, deprecated)]
     fn default() -> Self {
         let handle = unsafe {
             cpp!([] -> *mut bindings::OpResolver as "OpResolver*" {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -25,7 +25,6 @@ use crate::{Error, Result};
 pub use builtin_options::{
     BuiltinOptionsUnion, ConcatEmbeddingsOptionsT, ReshapeOptionsT, SqueezeOptionsT,
 };
-pub use builtin_options_impl::*;
 
 #[repr(C)]
 #[derive(Debug)]

--- a/src/model/stl/memory_impl.rs
+++ b/src/model/stl/memory_impl.rs
@@ -26,7 +26,7 @@ impl Deref for UniquePtr<crate::model::OperatorCodeT> {
         unsafe {
             let ptr = cpp!([self as "const std::unique_ptr<OperatorCodeT>*"] -> *const crate::model::OperatorCodeT as "const OperatorCodeT*" {
                 return self->get();
-            }) as *const Self::Target;
+            });
 
             ptr.as_ref().unwrap()
         }
@@ -39,7 +39,7 @@ impl DerefMut for UniquePtr<crate::model::OperatorCodeT> {
         unsafe {
             let ptr = cpp!([self as "std::unique_ptr<OperatorCodeT>*"] -> *mut crate::model::OperatorCodeT as "OperatorCodeT*" {
                 return self->get();
-            }) as *mut Self::Target;
+            });
 
             ptr.as_mut().unwrap()
         }
@@ -75,7 +75,7 @@ impl Deref for UniquePtr<crate::model::TensorT> {
         unsafe {
             let ptr = cpp!([self as "const std::unique_ptr<TensorT>*"] -> *const crate::model::TensorT as "const TensorT*" {
                 return self->get();
-            }) as *const Self::Target;
+            });
 
             ptr.as_ref().unwrap()
         }
@@ -88,7 +88,7 @@ impl DerefMut for UniquePtr<crate::model::TensorT> {
         unsafe {
             let ptr = cpp!([self as "std::unique_ptr<TensorT>*"] -> *mut crate::model::TensorT as "TensorT*" {
                 return self->get();
-            }) as *mut Self::Target;
+            });
 
             ptr.as_mut().unwrap()
         }
@@ -124,7 +124,7 @@ impl Deref for UniquePtr<crate::model::OperatorT> {
         unsafe {
             let ptr = cpp!([self as "const std::unique_ptr<OperatorT>*"] -> *const crate::model::OperatorT as "const OperatorT*" {
                 return self->get();
-            }) as *const Self::Target;
+            });
 
             ptr.as_ref().unwrap()
         }
@@ -137,7 +137,7 @@ impl DerefMut for UniquePtr<crate::model::OperatorT> {
         unsafe {
             let ptr = cpp!([self as "std::unique_ptr<OperatorT>*"] -> *mut crate::model::OperatorT as "OperatorT*" {
                 return self->get();
-            }) as *mut Self::Target;
+            });
 
             ptr.as_mut().unwrap()
         }
@@ -173,7 +173,7 @@ impl Deref for UniquePtr<crate::model::SubGraphT> {
         unsafe {
             let ptr = cpp!([self as "const std::unique_ptr<SubGraphT>*"] -> *const crate::model::SubGraphT as "const SubGraphT*" {
                 return self->get();
-            }) as *const Self::Target;
+            });
 
             ptr.as_ref().unwrap()
         }
@@ -186,7 +186,7 @@ impl DerefMut for UniquePtr<crate::model::SubGraphT> {
         unsafe {
             let ptr = cpp!([self as "std::unique_ptr<SubGraphT>*"] -> *mut crate::model::SubGraphT as "SubGraphT*" {
                 return self->get();
-            }) as *mut Self::Target;
+            });
 
             ptr.as_mut().unwrap()
         }
@@ -222,7 +222,7 @@ impl Deref for UniquePtr<crate::model::BufferT> {
         unsafe {
             let ptr = cpp!([self as "const std::unique_ptr<BufferT>*"] -> *const crate::model::BufferT as "const BufferT*" {
                 return self->get();
-            }) as *const Self::Target;
+            });
 
             ptr.as_ref().unwrap()
         }
@@ -235,7 +235,7 @@ impl DerefMut for UniquePtr<crate::model::BufferT> {
         unsafe {
             let ptr = cpp!([self as "std::unique_ptr<BufferT>*"] -> *mut crate::model::BufferT as "BufferT*" {
                 return self->get();
-            }) as *mut Self::Target;
+            });
 
             ptr.as_mut().unwrap()
         }
@@ -271,7 +271,7 @@ impl Deref for UniquePtr<crate::model::QuantizationParametersT> {
         unsafe {
             let ptr = cpp!([self as "const std::unique_ptr<QuantizationParametersT>*"] -> *const crate::model::QuantizationParametersT as "const QuantizationParametersT*" {
                 return self->get();
-            }) as *const Self::Target;
+            });
 
             ptr.as_ref().unwrap()
         }
@@ -284,7 +284,7 @@ impl DerefMut for UniquePtr<crate::model::QuantizationParametersT> {
         unsafe {
             let ptr = cpp!([self as "std::unique_ptr<QuantizationParametersT>*"] -> *mut crate::model::QuantizationParametersT as "QuantizationParametersT*" {
                 return self->get();
-            }) as *mut Self::Target;
+            });
 
             ptr.as_mut().unwrap()
         }
@@ -320,7 +320,7 @@ impl Deref for UniquePtr<crate::model::ModelT> {
         unsafe {
             let ptr = cpp!([self as "const std::unique_ptr<ModelT>*"] -> *const crate::model::ModelT as "const ModelT*" {
                 return self->get();
-            }) as *const Self::Target;
+            });
 
             ptr.as_ref().unwrap()
         }
@@ -333,7 +333,7 @@ impl DerefMut for UniquePtr<crate::model::ModelT> {
         unsafe {
             let ptr = cpp!([self as "std::unique_ptr<ModelT>*"] -> *mut crate::model::ModelT as "ModelT*" {
                 return self->get();
-            }) as *mut Self::Target;
+            });
 
             ptr.as_mut().unwrap()
         }
@@ -369,7 +369,7 @@ impl Deref for UniquePtr<crate::model::MetadataT> {
         unsafe {
             let ptr = cpp!([self as "const std::unique_ptr<MetadataT>*"] -> *const crate::model::MetadataT as "const MetadataT*" {
                 return self->get();
-            }) as *const Self::Target;
+            });
 
             ptr.as_ref().unwrap()
         }
@@ -382,7 +382,7 @@ impl DerefMut for UniquePtr<crate::model::MetadataT> {
         unsafe {
             let ptr = cpp!([self as "std::unique_ptr<MetadataT>*"] -> *mut crate::model::MetadataT as "MetadataT*" {
                 return self->get();
-            }) as *mut Self::Target;
+            });
 
             ptr.as_mut().unwrap()
         }

--- a/src/model/stl/vector.rs
+++ b/src/model/stl/vector.rs
@@ -24,11 +24,23 @@ pub trait VectorSlice {
     }
 
     fn as_slice(&self) -> &[Self::Item] {
-        unsafe { slice::from_raw_parts(self.get_ptr(), self.size()) }
+        let size = self.size();
+
+        if size == 0 {
+            &[]
+        } else {
+            unsafe { slice::from_raw_parts(self.get_ptr(), size) }
+        }
     }
 
     fn as_mut_slice(&mut self) -> &mut [Self::Item] {
-        unsafe { slice::from_raw_parts_mut(self.get_mut_ptr(), self.size()) }
+        let size = self.size();
+
+        if size == 0 {
+            &mut []
+        } else {
+            unsafe { slice::from_raw_parts_mut(self.get_mut_ptr(), size) }
+        }
     }
 }
 


### PR DESCRIPTION
To workaround rust-lang/rust-bindgen#2157, mark type parameter `_Tp` of vector as non-`Copy`able. It unblocks building against `libstdc++-12-dev`.

I also bumped `bindgen` to the latest version. It resolves build failure on clang-18 or later (rust-lang/rust-bindgen#2689).